### PR TITLE
Feature: add @here when tests fail

### DIFF
--- a/.github/workflows/call-run-browserstack.yml
+++ b/.github/workflows/call-run-browserstack.yml
@@ -69,7 +69,7 @@ jobs:
               JOB_STATUS="⚠️ Tests timed out, not all tests passed."
               ;;
             "failed")
-              JOB_STATUS="‼️ Tests failed, check the pipeline."
+              JOB_STATUS="‼️ Tests failed, check the pipeline. <!here>"
               ;;
             *)
               JOB_STATUS="❓ Something went wrong, check the pipeline."


### PR DESCRIPTION
This commit will include an @here in a message when the tests fail.

See https://api.slack.com/reference/surfaces/formatting#special-mentions for the <!__> syntax  in app-published messages.