### PR TITLE
Feature: remove !channel notification

### DIFF
--- a/.github/workflows/call-run-browserstack.yml
+++ b/.github/workflows/call-run-browserstack.yml
@@ -69,7 +69,7 @@ jobs:
               JOB_STATUS="⚠️ Tests timed out, not all tests passed."
               ;;
             "failed")
-              JOB_STATUS="‼️ Tests failed, check the pipeline. <!channel>"
+              JOB_STATUS="‼️ Tests failed, check the pipeline."
               ;;
             *)
               JOB_STATUS="❓ Something went wrong, check the pipeline."


### PR DESCRIPTION
This commit removes the <!channel> notification on test failures.

Pursuant to a team discussion on the signal to noise ratio at the moment.